### PR TITLE
Fix SDK examples

### DIFF
--- a/scripts/hardhat/add-liquidity/addLiquidityProportional.ts
+++ b/scripts/hardhat/add-liquidity/addLiquidityProportional.ts
@@ -30,6 +30,7 @@ export async function addLiquidityProportional() {
   };
   const slippage = Slippage.fromPercentage('5'); // 5%
 
+  // Use balancer api to fetch pool state
   const balancerApi = new BalancerApi('https://api-v3.balancer.fi/', chainId);
   const poolState = await balancerApi.pools.fetchPoolState(aaveLidowETHwstETHPool);
 

--- a/scripts/hardhat/add-liquidity/addLiquidityProportional.ts
+++ b/scripts/hardhat/add-liquidity/addLiquidityProportional.ts
@@ -24,7 +24,7 @@ export async function addLiquidityProportional() {
   const rpcUrl = hre.config.networks.hardhat.forking?.url as string;
   const kind = AddLiquidityKind.Proportional;
   const referenceAmount = {
-    rawAmount: parseUnits('1', 18),
+    rawAmount: parseUnits('10', 18),
     decimals: 18,
     address: waEthLidowETH,
   };
@@ -55,7 +55,7 @@ export async function addLiquidityProportional() {
     ...queryOutput,
     amountsIn: queryOutput.amountsIn.map((amountIn: TokenAmount) => {
       const token = new Token(amountIn.token.chainId, amountIn.token.address, amountIn.token.decimals);
-      return TokenAmount.fromRawAmount(token, amountIn.amount * 2n);
+      return TokenAmount.fromRawAmount(token, (amountIn.amount * 170n) / 100n); // add extra 70% to amounts that are used to calculate "MaxAmountsIn" (extra 50% not enough?!?)
     }),
   };
 

--- a/scripts/hardhat/add-liquidity/addLiquidityProportional.ts
+++ b/scripts/hardhat/add-liquidity/addLiquidityProportional.ts
@@ -1,5 +1,5 @@
 import { parseUnits, publicActions } from 'viem';
-import { setupTokenBalances, approveOnToken, waEthLidowETH, aaveLidowETHwstETHPool } from '../utils';
+import { getPoolTokenBalances, approveOnToken, waEthLidowETH, aaveLidowETHwstETHPool } from '../utils';
 import hre from 'hardhat';
 
 import {
@@ -82,7 +82,7 @@ export async function addLiquidityProportional() {
   return hash;
 }
 
-setupTokenBalances()
+getPoolTokenBalances()
   .then(() => addLiquidityProportional())
   .then(() => process.exit())
   .catch((error) => {

--- a/scripts/hardhat/add-liquidity/addLiquidityProportionalToERC4626Pool.ts
+++ b/scripts/hardhat/add-liquidity/addLiquidityProportionalToERC4626Pool.ts
@@ -11,6 +11,9 @@ import {
   AddLiquidityBoostedProportionalInput,
   MAX_UINT256,
   PERMIT2,
+  TokenAmount,
+  Token,
+  AddLiquidityBoostedQueryOutput,
 } from '@balancer/sdk';
 
 // npx hardhat run scripts/hardhat/add-liquidity/addLiquidityProportionalToERC4626Pool.ts
@@ -20,13 +23,13 @@ export async function addLiquidityProportionalToERC4626Pool() {
   const [walletClient] = await hre.viem.getWalletClients();
   const rpcUrl = hre.config.networks.hardhat.forking?.url as string;
   const kind = AddLiquidityKind.Proportional;
-  const tokensIn: `0x${string}`[] = [wETH, wstETH];
   const referenceAmount = {
-    rawAmount: parseUnits('10', 18),
+    rawAmount: parseUnits('1', 18),
     decimals: 18,
     address: wETH,
   };
-  const slippage = Slippage.fromPercentage('25'); // 25% TODO: fix insane slippage requirement
+  const tokensIn: `0x${string}`[] = [wETH, wstETH];
+  const slippage = Slippage.fromPercentage('5');
 
   // Approve the permit2 contract as spender of tokens
   for (const tokenAddress of tokensIn) {
@@ -50,16 +53,24 @@ export async function addLiquidityProportionalToERC4626Pool() {
 
   console.log(`Expected BPT Out: ${queryOutput.bptOut.amount.toString()}`);
 
+  const queryOutputWithAdjustedAmounts: AddLiquidityBoostedQueryOutput = {
+    ...queryOutput,
+    amountsIn: queryOutput.amountsIn.map((amountIn: TokenAmount) => {
+      const token = new Token(amountIn.token.chainId, amountIn.token.address, amountIn.token.decimals);
+      return TokenAmount.fromRawAmount(token, (amountIn.amount * 110n) / 100n); // add extra 10% to amounts that are used to calculate "MaxAmountsIn"
+    }),
+  };
+
   // Use helper to create the necessary permit2 signatures
   const permit2 = await Permit2Helper.signAddLiquidityBoostedApproval({
-    ...queryOutput,
+    ...queryOutputWithAdjustedAmounts,
     slippage,
     client: walletClient.extend(publicActions),
     owner: walletClient.account,
   });
 
   // Applies slippage to the BPT out amount and constructs the call
-  const call = addLiquidity.buildCallWithPermit2({ ...queryOutput, slippage }, permit2);
+  const call = addLiquidity.buildCallWithPermit2({ ...queryOutputWithAdjustedAmounts, slippage }, permit2);
 
   console.log(`Min BPT Out: ${call.minBptOut.amount.toString()}`);
 

--- a/scripts/hardhat/add-liquidity/addLiquidityProportionalToERC4626Pool.ts
+++ b/scripts/hardhat/add-liquidity/addLiquidityProportionalToERC4626Pool.ts
@@ -57,7 +57,7 @@ export async function addLiquidityProportionalToERC4626Pool() {
     ...queryOutput,
     amountsIn: queryOutput.amountsIn.map((amountIn: TokenAmount) => {
       const token = new Token(amountIn.token.chainId, amountIn.token.address, amountIn.token.decimals);
-      return TokenAmount.fromRawAmount(token, amountIn.amount * 2n); // add extra to amounts that are used to calculate "MaxAmountsIn"
+      return TokenAmount.fromRawAmount(token, amountIn.amount * 2n); // add extra to amounts that are used to calculate "MaxAmountsIn" so it doesn't revert `SwapLimit(uint256,uint256)`
     }),
   };
 

--- a/scripts/hardhat/add-liquidity/addLiquidityProportionalToERC4626Pool.ts
+++ b/scripts/hardhat/add-liquidity/addLiquidityProportionalToERC4626Pool.ts
@@ -1,5 +1,5 @@
 import { parseUnits, publicActions } from 'viem';
-import { setupTokenBalances, wETH, wstETH, aaveLidowETHwstETHPool, approveOnToken } from '../utils';
+import { getPoolTokenBalances, wETH, wstETH, aaveLidowETHwstETHPool, approveOnToken } from '../utils';
 import hre from 'hardhat';
 
 import {
@@ -57,7 +57,7 @@ export async function addLiquidityProportionalToERC4626Pool() {
     ...queryOutput,
     amountsIn: queryOutput.amountsIn.map((amountIn: TokenAmount) => {
       const token = new Token(amountIn.token.chainId, amountIn.token.address, amountIn.token.decimals);
-      return TokenAmount.fromRawAmount(token, (amountIn.amount * 110n) / 100n); // add extra 10% to amounts that are used to calculate "MaxAmountsIn"
+      return TokenAmount.fromRawAmount(token, amountIn.amount * 2n); // add extra to amounts that are used to calculate "MaxAmountsIn"
     }),
   };
 
@@ -84,7 +84,7 @@ export async function addLiquidityProportionalToERC4626Pool() {
   return hash;
 }
 
-setupTokenBalances()
+getPoolTokenBalances()
   .then(() => addLiquidityProportionalToERC4626Pool())
   .then(() => process.exit())
   .catch((error) => {

--- a/scripts/hardhat/add-liquidity/addLiquidityUnbalanced.ts
+++ b/scripts/hardhat/add-liquidity/addLiquidityUnbalanced.ts
@@ -1,5 +1,5 @@
 import { parseUnits, publicActions } from 'viem';
-import { setupTokenBalances, approveOnToken, waEthLidowETH, waEthLidowstETH, aaveLidowETHwstETHPool } from '../utils';
+import { approveOnToken, waEthLidowETH, waEthLidowstETH, aaveLidowETHwstETHPool } from '../utils';
 import hre from 'hardhat';
 
 import {
@@ -77,10 +77,10 @@ export async function addLiquidityUnbalanced() {
   return hash;
 }
 
-setupTokenBalances()
-  .then(() => addLiquidityUnbalanced())
-  .then(() => process.exit())
-  .catch((error) => {
-    console.error(error);
-    process.exit(1);
-  });
+// setupTokenBalances()
+//   .then(() => addLiquidityUnbalanced())
+//   .then(() => process.exit())
+//   .catch((error) => {
+//     console.error(error);
+//     process.exit(1);
+//   });

--- a/scripts/hardhat/add-liquidity/addLiquidityUnbalanced.ts
+++ b/scripts/hardhat/add-liquidity/addLiquidityUnbalanced.ts
@@ -1,5 +1,5 @@
 import { parseUnits, publicActions } from 'viem';
-import { approveOnToken, waEthLidowETH, waEthLidowstETH, aaveLidowETHwstETHPool } from '../utils';
+import { getPoolTokenBalances, approveOnToken, waEthLidowETH, waEthLidowstETH, aaveLidowETHwstETHPool } from '../utils';
 import hre from 'hardhat';
 
 import {
@@ -77,10 +77,10 @@ export async function addLiquidityUnbalanced() {
   return hash;
 }
 
-// setupTokenBalances()
-//   .then(() => addLiquidityUnbalanced())
-//   .then(() => process.exit())
-//   .catch((error) => {
-//     console.error(error);
-//     process.exit(1);
-//   });
+getPoolTokenBalances()
+  .then(() => addLiquidityUnbalanced())
+  .then(() => process.exit())
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/scripts/hardhat/add-liquidity/addLiquidityUnbalancedToERC4626Pool.ts
+++ b/scripts/hardhat/add-liquidity/addLiquidityUnbalancedToERC4626Pool.ts
@@ -1,5 +1,5 @@
 import { parseUnits, publicActions } from 'viem';
-import { setupTokenBalances, approveOnToken, wETH, wstETH, aaveLidowETHwstETHPool } from '../utils';
+import { getPoolTokenBalances, approveOnToken, wETH, wstETH, aaveLidowETHwstETHPool } from '../utils';
 import hre from 'hardhat';
 
 import {
@@ -77,7 +77,7 @@ export async function addLiquidityUnbalancedToERC4626Pool() {
   return hash;
 }
 
-setupTokenBalances()
+getPoolTokenBalances()
   .then(() => addLiquidityUnbalancedToERC4626Pool())
   .then(() => process.exit())
   .catch((error) => {

--- a/scripts/hardhat/remove-liquidity/removeLiquidityProportional.ts
+++ b/scripts/hardhat/remove-liquidity/removeLiquidityProportional.ts
@@ -1,5 +1,5 @@
 import { parseEther, publicActions } from 'viem';
-import { setupTokenBalances, aaveLidowETHwstETHPool } from '../utils';
+import { getBptBalance, aaveLidowETHwstETHPool } from '../utils';
 import hre from 'hardhat';
 
 import {
@@ -86,7 +86,7 @@ export async function removeLiquidityProportional() {
   return hash;
 }
 
-setupTokenBalances()
+getBptBalance()
   .then(() => removeLiquidityProportional())
   .then(() => process.exit())
   .catch((error) => {

--- a/scripts/hardhat/remove-liquidity/removeLiquidityProportionalFromERC4626Pool.ts
+++ b/scripts/hardhat/remove-liquidity/removeLiquidityProportionalFromERC4626Pool.ts
@@ -1,5 +1,5 @@
 import { parseEther, publicActions } from 'viem';
-import { setupTokenBalances, aaveLidowETHwstETHPool, wETH, wstETH } from '../utils';
+import { getBptBalance, aaveLidowETHwstETHPool, wETH, wstETH } from '../utils';
 import hre from 'hardhat';
 
 import {
@@ -84,7 +84,7 @@ export async function removeLiquidityProportionalFromERC4626Pool() {
   return hash;
 }
 
-setupTokenBalances()
+getBptBalance()
   .then(() => removeLiquidityProportionalFromERC4626Pool())
   .then(() => process.exit())
   .catch((error) => {

--- a/scripts/hardhat/remove-liquidity/removeLiquidityProportionalFromERC4626Pool.ts
+++ b/scripts/hardhat/remove-liquidity/removeLiquidityProportionalFromERC4626Pool.ts
@@ -9,6 +9,9 @@ import {
   Slippage,
   PermitHelper,
   RemoveLiquidityBoostedProportionalInput,
+  TokenAmount,
+  Token,
+  RemoveLiquidityBoostedQueryOutput,
 } from '@balancer/sdk';
 
 // npx hardhat run scripts/hardhat/remove-liquidity/removeLiquidityProportionalFromERC4626Pool.ts
@@ -24,7 +27,7 @@ export async function removeLiquidityProportionalFromERC4626Pool() {
     address: aaveLidowETHwstETHPool,
   };
   const tokensOut = [wETH, wstETH]; // can be underlying or actual pool tokens
-  const slippage = Slippage.fromPercentage('25'); // 25% TODO: fix insane slippage requirement
+  const slippage = Slippage.fromPercentage('5'); // 5%
 
   const input: RemoveLiquidityBoostedProportionalInput = {
     chainId,
@@ -47,14 +50,22 @@ export async function removeLiquidityProportionalFromERC4626Pool() {
     amountsOut: queryOutput.amountsOut.map((a) => a.amount),
   });
 
-  const permit = await PermitHelper.signRemoveLiquidityBoostedApproval({
+  const queryOutputWithAdjustedAmounts: RemoveLiquidityBoostedQueryOutput = {
     ...queryOutput,
+    amountsOut: queryOutput.amountsOut.map((amountOut: TokenAmount) => {
+      const token = new Token(amountOut.token.chainId, amountOut.token.address, amountOut.token.decimals);
+      return TokenAmount.fromRawAmount(token, 0n); // Must override minAmountsOut or it causes revert `SwapLimit(uint256,uint256)`
+    }),
+  };
+
+  const permit = await PermitHelper.signRemoveLiquidityBoostedApproval({
+    ...queryOutputWithAdjustedAmounts,
     slippage,
     client: walletClient.extend(publicActions),
     owner: walletClient.account,
   });
 
-  const call = removeLiquidityBoosted.buildCallWithPermit({ ...queryOutput, slippage }, permit);
+  const call = removeLiquidityBoosted.buildCallWithPermit({ ...queryOutputWithAdjustedAmounts, slippage }, permit);
 
   console.log('\nWith slippage applied:');
   console.log(`Max BPT In: ${call.maxBptIn.amount}`);

--- a/scripts/hardhat/remove-liquidity/removeLiquiditySingleTokenExactIn.ts
+++ b/scripts/hardhat/remove-liquidity/removeLiquiditySingleTokenExactIn.ts
@@ -1,5 +1,5 @@
 import { parseEther, publicActions } from 'viem';
-import { setupTokenBalances, aaveLidowETHwstETHPool, waEthLidowETH } from '../utils';
+import { getBptBalance, aaveLidowETHwstETHPool, waEthLidowETH } from '../utils';
 import hre from 'hardhat';
 
 import {
@@ -76,7 +76,7 @@ export async function removeLiquiditySingleTokenExactIn() {
   return hash;
 }
 
-setupTokenBalances()
+getBptBalance()
   .then(() => removeLiquiditySingleTokenExactIn())
   .then(() => process.exit())
   .catch((error) => {

--- a/scripts/hardhat/remove-liquidity/removeLiquiditySingleTokenExactOut.ts
+++ b/scripts/hardhat/remove-liquidity/removeLiquiditySingleTokenExactOut.ts
@@ -1,5 +1,5 @@
 import { parseEther, publicActions } from 'viem';
-import { setupTokenBalances, aaveLidowETHwstETHPool, waEthLidowETH } from '../utils';
+import { getBptBalance, aaveLidowETHwstETHPool, waEthLidowETH } from '../utils';
 import hre from 'hardhat';
 
 import {
@@ -74,7 +74,7 @@ export async function removeLiquiditySingleTokenExactOut() {
   return hash;
 }
 
-setupTokenBalances()
+getBptBalance()
   .then(() => removeLiquiditySingleTokenExactOut())
   .then(() => process.exit())
   .catch((error) => {

--- a/scripts/hardhat/swap/swapSmartPath.ts
+++ b/scripts/hardhat/swap/swapSmartPath.ts
@@ -1,6 +1,6 @@
 import hre from 'hardhat';
 import { publicActions } from 'viem';
-import { setupTokenBalances, waEthLidowETH, waEthLidowstETH, approveOnToken } from '../utils';
+import { getPoolTokenBalances, waEthLidowETH, waEthLidowstETH, approveOnToken } from '../utils';
 
 import {
   SwapKind,
@@ -80,7 +80,7 @@ export async function swapSmartPath() {
   return hash;
 }
 
-setupTokenBalances()
+getPoolTokenBalances()
   .then(() => swapSmartPath())
   .then(() => process.exit())
   .catch((error) => {

--- a/scripts/hardhat/utils/addressRegistry.ts
+++ b/scripts/hardhat/utils/addressRegistry.ts
@@ -1,7 +1,8 @@
-export const wETH: `0x${string}` = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2'; // underlying
-export const waEthLidowETH: `0x${string}` = '0x0FE906e030a44eF24CA8c7dC7B7c53A6C4F00ce9'; // yield-bearing wrapped
+export const wETH: `0x${string}` = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2'; // underlying pool token
+export const waEthLidowETH: `0x${string}` = '0x0FE906e030a44eF24CA8c7dC7B7c53A6C4F00ce9'; // boosted pool token
 
-export const wstETH: `0x${string}` = '0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0'; // underlying
-export const waEthLidowstETH: `0x${string}` = '0x775f661b0bd1739349b9a2a3ef60be277c5d2d29'; // yield-bearing wrapped
+export const stETH: `0x${string}` = '0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84'; // asset for wstETH
+export const wstETH: `0x${string}` = '0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0'; // underlying pool token
+export const waEthLidowstETH: `0x${string}` = '0x775f661b0bd1739349b9a2a3ef60be277c5d2d29'; // boosted pool token
 
 export const aaveLidowETHwstETHPool: `0x${string}` = '0xc4Ce391d82D164c166dF9c8336DDF84206b2F812'; // https://balancer.fi/pools/ethereum/v3/0xc4ce391d82d164c166df9c8336ddf84206b2f812

--- a/scripts/hardhat/utils/setup.ts
+++ b/scripts/hardhat/utils/setup.ts
@@ -1,5 +1,5 @@
 import hre from 'hardhat';
-import { parseAbi, parseEther, formatEther, publicActions } from 'viem';
+import { parseAbi, parseEther, publicActions } from 'viem';
 import { wETH, waEthLidowETH, stETH, wstETH, waEthLidowstETH, aaveLidowETHwstETHPool, approveOnToken } from '.';
 import {
   Slippage,
@@ -14,23 +14,8 @@ import {
   Token,
 } from '@balancer/sdk';
 
-/**
- * Default account #0 starts each example with balances for:
- * - wETH (underlying)
- * - waEthLidowETH (erc4626)
- * - wstETH (underlying)
- * - waEthLidowstETH (erc4626)
- * - aaveLidowETHwstETHPool (BPT)
- */
-export async function setupTokenBalances() {
-  // console.log('Setting up token balances...');
-  await getUnderlyingPoolTokens();
-  await getBoostedPoolTokens();
-  await getBpt();
-  // await logTokenBalances();
-}
-
-async function getUnderlyingPoolTokens() {
+// Get account #0 some wETH and wstETH
+export async function getUnderlyingTokenBalances() {
   const [walletClient] = await hre.viem.getWalletClients();
   const UNDERLYING_AMOUNT = parseEther('1000');
 
@@ -62,9 +47,12 @@ async function getUnderlyingPoolTokens() {
   });
 }
 
-async function getBoostedPoolTokens() {
-  const [walletClient] = await hre.viem.getWalletClients();
+// Get account #0 some waEthLidowETH and waEthLidowstETH
+export async function getPoolTokenBalances() {
   const BOOSTED_AMOUNT = parseEther('100');
+  const [walletClient] = await hre.viem.getWalletClients();
+
+  await getUnderlyingTokenBalances();
 
   // Get waEthLidowETH
   await approveOnToken(wETH, waEthLidowETH, MAX_UINT256);
@@ -87,7 +75,10 @@ async function getBoostedPoolTokens() {
   });
 }
 
-export async function getBpt() {
+// Get account #0 some BPT for aaveLidowETHwstETHPool
+export async function getBptBalance() {
+  await getUnderlyingTokenBalances();
+
   const chainId = hre.network.config.chainId!;
   const [walletClient] = await hre.viem.getWalletClients();
   const rpcUrl = hre.config.networks.hardhat.forking?.url as string;
@@ -142,29 +133,29 @@ export async function getBpt() {
   });
 }
 
-export async function logTokenBalances() {
-  const [walletClient] = await hre.viem.getWalletClients();
-  const client = walletClient.extend(publicActions);
+// export async function logTokenBalances() {
+//   const [walletClient] = await hre.viem.getWalletClients();
+//   const client = walletClient.extend(publicActions);
 
-  const tokens = [
-    { address: wETH, name: 'wETH' },
-    { address: wstETH, name: 'wstETH' },
-    { address: waEthLidowETH, name: 'waEthLidowETH' },
-    { address: waEthLidowstETH, name: 'waEthLidowstETH' },
-    { address: aaveLidowETHwstETHPool, name: 'aaveLidowETHwstETHPool' },
-  ];
+//   const tokens = [
+//     { address: wETH, name: 'wETH' },
+//     { address: wstETH, name: 'wstETH' },
+//     { address: waEthLidowETH, name: 'waEthLidowETH' },
+//     { address: waEthLidowstETH, name: 'waEthLidowstETH' },
+//     { address: aaveLidowETHwstETHPool, name: 'aaveLidowETHwstETHPool' },
+//   ];
 
-  const balanceAbi = parseAbi(['function balanceOf(address account) view returns (uint256)']);
+//   const balanceAbi = parseAbi(['function balanceOf(address account) view returns (uint256)']);
 
-  await Promise.all(
-    tokens.map(async ({ address, name }) => {
-      const balance = await client.readContract({
-        address,
-        abi: balanceAbi,
-        functionName: 'balanceOf',
-        args: [walletClient.account.address],
-      });
-      console.log(`${name} Balance: ${formatEther(balance)}`);
-    })
-  );
-}
+//   await Promise.all(
+//     tokens.map(async ({ address, name }) => {
+//       const balance = await client.readContract({
+//         address,
+//         abi: balanceAbi,
+//         functionName: 'balanceOf',
+//         args: [walletClient.account.address],
+//       });
+//       console.log(`${name} Balance: ${formatEther(balance)}`);
+//     })
+//   );
+// }

--- a/scripts/hardhat/utils/setup.ts
+++ b/scripts/hardhat/utils/setup.ts
@@ -33,7 +33,7 @@ export async function setupTokenBalances() {
   await getWstETH();
 
   // 3. Proportionally add wETH to wstETH to aaveLidowETHwstETHPool (to get BPT)
-  await getBpt();
+  // await getBpt();
 
   // // 3. Remove liquidity from aaveLidowETHwstETHPool (to get waEthLidowETH and waEthLidowstETH)
   // await getBoostedPoolTokens();
@@ -81,14 +81,19 @@ async function getWstETH() {
     args: [3999999999999999999000n],
   });
 
-  const wstETHBalance = await publicClient.readContract({
+  await walletClient.writeContract({
     address: wstETH,
-    abi: parseAbi(['function balanceOf(address account) view returns (uint256)']),
-    functionName: 'balanceOf',
-    args: [walletClient.account.address],
+    abi: parseAbi(['function approve(address spender, uint256 amount)']),
+    functionName: 'approve',
+    args: [waEthLidowstETH, parseEther('2000')],
   });
 
-  console.log('wstETHBalance', wstETHBalance);
+  await walletClient.writeContract({
+    address: waEthLidowstETH,
+    abi: parseAbi(['function deposit(uint256 assets, address receiver)']),
+    functionName: 'deposit',
+    args: [parseEther('2000'), walletClient.account.address],
+  });
 }
 
 export async function getBpt() {
@@ -225,3 +230,10 @@ export async function logTokenBalances() {
     })
   );
 }
+
+setupTokenBalances()
+  .then(() => process.exit())
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/test/examples.ts
+++ b/test/examples.ts
@@ -6,7 +6,7 @@ import {
   addLiquidityUnbalancedToERC4626Pool,
   addLiquidityProportionalToERC4626Pool,
 } from '../scripts/hardhat/add-liquidity';
-import { setupTokenBalances } from '../scripts/hardhat/utils/setup';
+import { getPoolTokenBalances } from '../scripts/hardhat/utils/setup';
 import { PublicClient } from 'viem';
 
 // TODO: figure out how to run basic test that checks if tx returned by each example script is success
@@ -16,7 +16,7 @@ describe('Example pool operation scripts', function () {
 
   before(async function () {
     publicClient = await hre.viem.getPublicClient();
-    await setupTokenBalances();
+    await getPoolTokenBalances();
   });
 
   describe('Add Liquidity', function () {

--- a/test/examples.ts
+++ b/test/examples.ts
@@ -2,42 +2,46 @@ import { expect } from 'chai';
 import hre from 'hardhat';
 import {
   addLiquidityUnbalanced,
-  addLiquidityUnbalancedToERC4626Pool,
   addLiquidityProportional,
+  addLiquidityUnbalancedToERC4626Pool,
   addLiquidityProportionalToERC4626Pool,
 } from '../scripts/hardhat/add-liquidity';
+import { setupTokenBalances } from '../scripts/hardhat/utils/setup';
 import { PublicClient } from 'viem';
 
-// TODO: figure out how to run basic tests that checks if tx returned by each example script is success
-// PROBLEM: the setup for each script runs like 4 times and fails before any tests execute, even tho `setupTokenBalances()` is never even called by this test
+// TODO: figure out how to run basic test that checks if tx returned by each example script is success
+// PROBLEM: the setup for each script runs like 4 times and fails before any tests execute and they seem to time out before finishinsg?
 describe('Example pool operation scripts', function () {
   let publicClient: PublicClient;
 
   before(async function () {
     publicClient = await hre.viem.getPublicClient();
+    await setupTokenBalances();
   });
 
-  // describe('Add Liquidity', function () {
-  it('Unbalanced Standard', async function () {
-    expect(true).to.equal(true);
-    const hash = await addLiquidityUnbalanced();
-    const txReceipt = await publicClient.waitForTransactionReceipt({ hash });
-    expect(txReceipt.status).to.equal('success');
+  describe('Add Liquidity', function () {
+    it('Proportional Standard', async function () {
+      const hash = await addLiquidityProportional();
+      const txReceipt = await publicClient.waitForTransactionReceipt({ hash });
+      expect(txReceipt.status).to.equal('success');
+    });
+
+    it('Unbalanced Standard', async function () {
+      const hash = await addLiquidityUnbalanced();
+      const txReceipt = await publicClient.waitForTransactionReceipt({ hash });
+      expect(txReceipt.status).to.equal('success');
+    });
+
+    it('Proportional Boosted', async function () {
+      const hash = await addLiquidityProportionalToERC4626Pool();
+      const txReceipt = await publicClient.waitForTransactionReceipt({ hash });
+      expect(txReceipt.status).to.equal('success');
+    });
+
+    it('Unbalanced Boosted', async function () {
+      const hash = await addLiquidityUnbalancedToERC4626Pool();
+      const txReceipt = await publicClient.waitForTransactionReceipt({ hash });
+      expect(txReceipt.status).to.equal('success');
+    });
   });
-  // it('Unbalanced Boosted', async function () {
-  //   const hash = await addLiquidityUnbalancedToERC4626Pool();
-  //   const txReceipt = await publicClient.waitForTransactionReceipt({ hash });
-  //   expect(txReceipt.status).to.equal('success');
-  // });
-  // it('Proportional Standard', async function () {
-  //   const hash = await addLiquidityProportional();
-  //   const txReceipt = await publicClient.waitForTransactionReceipt({ hash });
-  //   expect(txReceipt.status).to.equal('success');
-  // });
-  // it('Proportional Boosted', async function () {
-  //   const hash = await addLiquidityProportionalToERC4626Pool();
-  //   const txReceipt = await publicClient.waitForTransactionReceipt({ hash });
-  //   expect(txReceipt.status).to.equal('success');
-  // });
-  // });
 });


### PR DESCRIPTION
Closes #1 

### Summary
-  For `addLiquidityProportional.ts` SDK query calculates `maxAmountsIn` too low so it reverts `AmountInAboveMax`
- For `addLiquidityProportionalToERC4626Pool.ts` SDK query calculates `MaxAmountsIn` too low so it reverts `SwapLimit`
- For `removeLiquidityProportional.ts` SDK query calculates `minAmountsOut` too high so it reverts `AmountOutBelowMin`
- For `removeLiquidityProportionalFromERC4626.ts` SDK query calculates `minAmountsOut` too high so it reverts `SwapLimit`